### PR TITLE
Ignore PEP8 import error

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,6 @@ deps = -r{toxinidir}/requirements.txt
        git+https://github.com/openstack/tempest
 commands = pep8 argus
            pylint --rcfile=pylintrc argus
+
+[pep8]
+ignore = E402


### PR DESCRIPTION
Ignores E402 errors caused by the objects
declared above the imports.
