### PR TITLE
Refactor scenario inheritance syntax

### DIFF
--- a/argus/config.py
+++ b/argus/config.py
@@ -56,7 +56,7 @@ class _ScenarioSection(object):
     taking in account their parents, if any.
     To specify a parent for a scenario, use this syntax:
 
-       [scenario inherits base_scenario]
+       [scenario : base_scenario]
     """
 
     def __init__(self, section_key, parser):
@@ -65,7 +65,7 @@ class _ScenarioSection(object):
         self._key = section_key
         self.scenario_name = None
 
-        name, attr, parent = section_key.partition(" inherits ")
+        name, attr, parent = section_key.partition(":")
         if attr:
             self._parent = parent.strip()
         self.scenario_name = name.strip().partition("scenario_")[2]

--- a/etc/argus.conf
+++ b/etc/argus.conf
@@ -37,14 +37,14 @@ image = windows
 introspection = argus.introspection.cloud.windows:InstanceIntrospection
 
 
-[scenario_smoke_windows inherits base_smoke_windows]
+[scenario_smoke_windows : base_smoke_windows]
 
 test_classes = argus.tests.cloud.windows.test_smoke:TestSmoke
 userdata =
 metadata = {}
 
 
-[scenario_scripts_smoke_windows inherits base_smoke_windows]
+[scenario_scripts_smoke_windows : base_smoke_windows]
 
 test_classes = argus.tests.cloud.windows.test_smoke:TestScriptsUserdataSmoke
 recipe = argus.recipes.cloud.windows:CloudbaseinitScriptRecipe
@@ -52,7 +52,7 @@ userdata = argus.windows.multipart_userdata
 metadata = {}
 
 
-[scenario_user_already_created_windows inherits base_smoke_windows]
+[scenario_user_already_created_windows : base_smoke_windows]
 
 test_classes = argus.tests.cloud.smoke:CreatedUserTest,
                argus.tests.cloud.smoke:PasswordSmokeTest
@@ -61,7 +61,7 @@ userdata =
 metadata = {}
 
 
-[scenario_generic_smoke_windows inherits base_smoke_windows]
+[scenario_generic_smoke_windows : base_smoke_windows]
 
 # Generic scenario, which tests some unrelated stuff:
 #
@@ -74,7 +74,7 @@ userdata = argus.windows.ec2script
 metadata = {"admin_pass": "PASsw0r4&!="}
 
 
-[scenario_smoke_configdrive_windows inherits base_smoke_windows]
+[scenario_smoke_configdrive_windows : base_smoke_windows]
 
 test_classes = argus.tests.cloud.windows.test_smoke:TestSmoke
 userdata =
@@ -82,10 +82,9 @@ metadata = {}
 service_type = configdrive
 
 
-[scenario_smoke_rescue_windows inherits base_smoke_windows]
+[scenario_smoke_rescue_windows : base_smoke_windows]
 
 scenario = argus.scenario:RescueWindowsScenario
 test_classes = argus.tests.cloud.smoke:PasswordRescueSmokeTest
 userdata =
 metadata = {"admin_pass": "PASsw0r4&!="}
-

--- a/etc/argus.conf.sample
+++ b/etc/argus.conf.sample
@@ -60,7 +60,7 @@ os_type = Windows
 # be looked into the parent, if any, if they don't exist in the current scenario.
 # To specify a parent for a scenario, use this syntax:
 #
-# [scenario inherits base_scenario]
+# [scenario : base_scenario]
 
 # Mark the type of this scenario. Scenarios can have types such as
 # `smoke`, `deep` or no type at all. Scenarios can be filtered

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ class TestConfig(unittest.TestCase):
         metadata = 7
         introspection = something
 
-        [scenario_windows inherits base_scenario]
+        [scenario_windows : base_scenario]
         type = smoke
         scenario = 3
         image = 8


### PR DESCRIPTION
Use a colon to delimit the base scenario.
