### PR TITLE
Keep a standard between error messages

### DIFF
--- a/argus/recipes/base.py
+++ b/argus/recipes/base.py
@@ -58,8 +58,8 @@ class BaseRecipe(object):
         stdout, stderr, return_code = self._remote_client.run_remote_cmd(cmd)
         if return_code:
             raise exceptions.ArgusError(
-                "command {command!r} failed with "
-                "return code {return_code!r}"
+                "Command {command!r} failed with "
+                "return code {return_code!r}."
                 .format(command=cmd,
                         return_code=return_code))
         return stdout, stderr
@@ -92,7 +92,7 @@ class BaseRecipe(object):
                 count += 1
                 if retry_count and count >= retry_count:
                     raise exceptions.ArgusTimeoutError(
-                        "command {!r} failed too many times"
+                        "Command {!r} failed too many times."
                         .format(cmd))
                 time.sleep(retry_count_interval)
 

--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -60,7 +60,7 @@ def _get_git_link():
         if not href.endswith('.exe'):
             continue
         return href
-    raise exceptions.ArgusError("git download link not found.")
+    raise exceptions.ArgusError("Git download link not found.")
 
 
 class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):

--- a/argus/remote_client.py
+++ b/argus/remote_client.py
@@ -67,7 +67,7 @@ class WinRemoteClient(object):
             if exit_code:
                 raise exceptions.ArgusError(
                     "Executing command {command!r} failed with "
-                    "exit code {exit_code!r} and output {output!r}"
+                    "exit code {exit_code!r} and output {output!r}."
                     .format(command=command,
                             exit_code=exit_code,
                             output=stdout))

--- a/argus/scenario.py
+++ b/argus/scenario.py
@@ -160,7 +160,7 @@ class BaseArgusScenario(object):
             return self._isolated_creds.get_admin_creds()
         except NotImplementedError:
             raise exceptions.ArgusError(
-                'Admin Credentials are not available')
+                'Admin Credentials are not available.')
 
     def _create_server(self, wait_until='ACTIVE', **kwargs):
         _, server = self._servers_client.create_server(
@@ -350,7 +350,7 @@ class BaseArgusScenario(object):
 
     def prepare_instance(self):
         if self._recipe is None:
-            raise exceptions.ArgusError('recipe must be set')
+            raise exceptions.ArgusError('Recipe must be set.')
 
         LOG.info("Preparing instance...")
         # pylint: disable=not-callable

--- a/argus/tests/cloud/util.py
+++ b/argus/tests/cloud/util.py
@@ -67,7 +67,7 @@ def requires_service(service_type='http'):
         def wrapper(self):
             if self.service_type != service_type:
                 raise unittest.SkipTest(
-                    "Not the expected service type.""")
+                    "Not the expected service type.")
             return func(self)
         return wrapper
     return factory

--- a/argus/util.py
+++ b/argus/util.py
@@ -65,7 +65,7 @@ def decrypt_password(private_key, password):
     out, err = proc.communicate(unencoded)
     proc.stdin.close()
     if proc.returncode:
-        raise Exception("Failed calling openssl with error: {!r}"
+        raise Exception("Failed calling openssl with error: {!r}."
                         .format(err))
     return out
 


### PR DESCRIPTION
Raise an exception with a capital message
and with ending punctuation. The output must look like that:
"SomeError: Some error message."
- Logging messages keep the same standard.
