### PR TITLE
Fix return value unpack

### DIFF
--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -110,8 +110,6 @@ class BaseSmokeTests(CreatedUserTest,
     def test_disk_expanded(self):
         # Test the disk expanded properly.
         image = self.manager.get_image_ref()
-        if isinstance(image, tuple):
-            image = image[1]
         datastore_size = image['OS-EXT-IMG-SIZE:size']
         disk_size = self.introspection.get_disk_size()
         self.assertGreater(disk_size, datastore_size)
@@ -119,7 +117,7 @@ class BaseSmokeTests(CreatedUserTest,
     def test_hostname_set(self):
         # Test that the hostname was properly set.
         instance_hostname = self.introspection.get_instance_hostname()
-        server = self.manager.instance_server()[1]
+        server = test_util.get_dict(self.manager.instance_server())
 
         self.assertEqual(instance_hostname,
                          str(server['name'][:15]).lower())

--- a/argus/tests/cloud/util.py
+++ b/argus/tests/cloud/util.py
@@ -25,6 +25,7 @@ from argus import util
 __all__ = (
     'skip_unless_dnsmasq_configured',
     'requires_service',
+    'get_dict',
 )
 
 
@@ -71,3 +72,10 @@ def requires_service(service_type='http'):
             return func(self)
         return wrapper
     return factory
+
+
+def get_dict(response_body):
+    """Get the dict-like object from a manager response."""
+    if isinstance(response_body, tuple):
+        response_body = response_body[1]
+    return response_body


### PR DESCRIPTION
Some API calls encapsulates the `response` into the dict-like object.
