### PR TITLE
Revert with single response unpack

### DIFF
--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -117,7 +117,7 @@ class BaseSmokeTests(CreatedUserTest,
     def test_hostname_set(self):
         # Test that the hostname was properly set.
         instance_hostname = self.introspection.get_instance_hostname()
-        server = test_util.get_dict(self.manager.instance_server())
+        server = self.manager.instance_server()
 
         self.assertEqual(instance_hostname,
                          str(server['name'][:15]).lower())

--- a/argus/tests/cloud/util.py
+++ b/argus/tests/cloud/util.py
@@ -25,7 +25,6 @@ from argus import util
 __all__ = (
     'skip_unless_dnsmasq_configured',
     'requires_service',
-    'get_dict',
 )
 
 
@@ -72,10 +71,3 @@ def requires_service(service_type='http'):
             return func(self)
         return wrapper
     return factory
-
-
-def get_dict(response_body):
-    """Get the dict-like object from a manager response."""
-    if isinstance(response_body, tuple):
-        response_body = response_body[1]
-    return response_body


### PR DESCRIPTION
Due to tempest updates, now the returns are dict-like objects.
