### PR TITLE
Add option for installation files patch

### DIFF
--- a/argus/introspection/cloud/windows.py
+++ b/argus/introspection/cloud/windows.py
@@ -67,7 +67,7 @@ def _escape_path(path):
     return path
 
 
-def _get_cbinit_dir(execute_function):
+def get_cbinit_dir(execute_function):
     """Get the location of cloudbase-init from the instance."""
     stdout = execute_function(
         'powershell "(Get-WmiObject  Win32_OperatingSystem).'
@@ -100,7 +100,7 @@ def _get_cbinit_dir(execute_function):
 
 def get_python_dir(execute_function):
     """Find python directory from the cb-init installation."""
-    cbinit_dir = _get_cbinit_dir(execute_function)
+    cbinit_dir = get_cbinit_dir(execute_function)
     command = 'dir "{}" /b'.format(cbinit_dir)
     stdout = execute_function(command).strip()
     names = list(filter(None, stdout.splitlines()))

--- a/argus/recipes/cloud/base.py
+++ b/argus/recipes/cloud/base.py
@@ -79,6 +79,10 @@ class BaseCloudbaseinitRecipe(base.BaseRecipe):
         """
 
     @abc.abstractmethod
+    def replace_install(self):
+        """Do whatever is necessary to replace the installation."""
+
+    @abc.abstractmethod
     def replace_code(self):
         """Do whatever is necessary to replace the code for cloudbaseinit."""
 
@@ -96,6 +100,7 @@ class BaseCloudbaseinitRecipe(base.BaseRecipe):
         self.wait_for_boot_completion()
         self.get_installation_script()
         self.install_cbinit()
+        self.replace_install()
         self.install_git()
         self.replace_code()
         # pause the process until user is satisfied with his changes

--- a/argus/util.py
+++ b/argus/util.py
@@ -137,6 +137,10 @@ def parse_cli():
                         help="Give a path to the argus conf. "
                              "It should be an .ini file format "
                              "with a section called [argus].")
+    parser.add_argument("--patch-install", metavar="URL",
+                        help='Pass a link that points *directly* to a '
+                             'zip file containing the installed version. '
+                             'The content will just replace the files.')
     parser.add_argument("--git-command", type=str, default=None,
                         help="Pass a git command which should be interpreted "
                              "by a recipe.")


### PR DESCRIPTION
Through --patch-install option the already installed kit
can be replaced with other something downloaded and
extracted from an URL.
