### PR TITLE
Proper import of novaclient

### DIFF
--- a/argus/environment.py
+++ b/argus/environment.py
@@ -19,7 +19,7 @@ import shlex
 import subprocess
 import time
 
-import novaclient.v1_1.client as nova
+import novaclient.client as nova
 import six
 
 from argus import util


### PR DESCRIPTION
The v1 API was explicitly imported but it was just
chainloaded into v2. Use the correct way anyway.
