### PR TITLE
Speed up the copying/downloading process

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -140,9 +140,12 @@ class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):
         LOG.info("Replacing cloudbaseinit's files...")
 
         LOG.debug("Download and extract installation bundle.")
-        cmd = ("powershell Invoke-webrequest -uri "
-               "{} -outfile 'C:\\install.zip'"
-               .format(link))
+        if link.startswith("\\\\"):
+            cmd = 'copy "{}" "C:\\install.zip"'.format(link)
+        else:
+            cmd = ("powershell Invoke-webrequest -uri "
+                   "{} -outfile 'C:\\install.zip'"
+                   .format(link))
         self._execute_with_retry(cmd)
         cmds = [
             "Add-Type -A System.IO.Compression.FileSystem",


### PR DESCRIPTION
Use copy instead of webrequest when the targeted file
is available within a share (network location).
