### PR TITLE
Keep a standard between entities naming

### DIFF
--- a/argus/scenarios/base.py
+++ b/argus/scenarios/base.py
@@ -171,7 +171,7 @@ class BaseArgusScenario(object):
 
     def _create_server(self, wait_until='ACTIVE', **kwargs):
         server = self._servers_client.create_server(
-            util.rand_name(self.__class__.__name__ + "-instance"),
+            util.rand_name(self.__class__.__name__) + "-instance",
             self._image.image_ref,
             self._image.flavor_ref,
             **kwargs)


### PR DESCRIPTION
Put the "-instace" suffix where it should be.
