### PR TITLE
Fix network interfaces details parsing

### DIFF
--- a/argus/resources/windows/network_details.ps1
+++ b/argus/resources/windows/network_details.ps1
@@ -5,13 +5,23 @@
 
 $nics = Get-WmiObject -ComputerName . Win32_NetworkAdapterConfiguration | `
         Where-Object { $_.IPAddress -ne $null }
+$sep = "----"
+
 foreach ($nic in $nics)
 {
-    $nic.MACAddress
-    $nic.IPAddress
-    $nic.DefaultIPGateway
-    $nic.IPSubnet
-    $nic.DNSServerSearchOrder
-    $nic.DHCPEnabled
-    ""
+    # On some cases, the join is used only to
+    # normalize NULs to empty strings.
+    $details = @(
+        $sep,
+        ($nic.MACAddress -join " "),
+        ($nic.IPAddress -join " "),
+        ($nic.DefaultIPGateway -join " "),
+        ($nic.IPSubnet -join " "),
+        ($nic.DNSServerSearchOrder -join " "),
+        ($nic.DHCPEnabled -join " ")
+    )
+    foreach ($detail in $details)
+    {
+        echo $detail
+    }
 }


### PR DESCRIPTION
Keep a standard between the number of fields under the blocks.
Also, use a distinctive separator between the blocks. Split the
output by that separator (after removing the excess), then each
block by EOL and each field by space into details.
