### PR TITLE
Better static network configuration testing

### DIFF
--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -168,3 +168,22 @@ class TestsBaseSmoke(TestCreatedUser,
         self.assertTrue(output, "Console output was empty.")
         lines = len(output.split('\n'))
         self.assertEqual(lines, 10)
+
+
+class TestStaticNetwork(base.TestBaseArgus):
+
+    def test_static_network(self):
+        """Check if the attached NICs were properly configured."""
+        # Get network adapter details within the guest compute node.
+        guest_nics = self.manager.get_network_interfaces()
+        # Get network adapter details within the instance.
+        instance_nics = self.introspection.get_network_interfaces()
+        # Filter them by DHCP disabled status for static checks.
+        filter_nics = lambda nics: [nic for nic in nics if not nic["dhcp"]]
+        guest_nics = filter_nics(guest_nics)
+        instance_nics = filter_nics(instance_nics)
+        # Sort by hardware address and compare results.
+        sort_func = lambda arg: arg["mac"]
+        instance_nics.sort(key=sort_func)
+        guest_nics.sort(key=sort_func)
+        self.assertEqual(guest_nics, instance_nics)

--- a/argus/tests/cloud/windows/test_smoke.py
+++ b/argus/tests/cloud/windows/test_smoke.py
@@ -143,22 +143,3 @@ class TestCatchingSpecialize(base.TestBaseArgus):
     def test_traceback_occurred(self):
         instance_traceback = self.introspection.get_cloudbaseinit_traceback()
         self.assertIn('ImportError: No module named mtu', instance_traceback)
-
-
-class TestStaticNetwork(base.TestBaseArgus):
-
-    def test_static_network(self):
-        """Check if the attached NICs were properly configured."""
-        # Get network adapter details within the guest compute node.
-        guest_nics = self.manager.get_network_interfaces()
-        # Get network adapter details within the windows instance.
-        instance_nics = self.introspection.get_network_interfaces()
-        # Filter them by DHCP disabled status for static checks.
-        filter_nics = lambda nics: [nic for nic in nics if not nic["dhcp"]]
-        guest_nics = filter_nics(guest_nics)
-        instance_nics = filter_nics(instance_nics)
-        # Sort by hardware address and compare results.
-        sort_func = lambda arg: arg["mac"]
-        instance_nics.sort(key=sort_func)
-        guest_nics.sort(key=sort_func)
-        self.assertEqual(guest_nics, instance_nics)

--- a/etc/argus.conf
+++ b/etc/argus.conf
@@ -43,6 +43,12 @@ DEFAULT.config_drive_format=iso9660
 DEFAULT.config_drive_cdrom=false
 
 
+[devstack_configuration_static_network]
+
+config_file = /etc/nova/nova.conf
+DEFAULT.flat_injected=True
+
+
 [environment_devstack_configdrive_vfat_cdrom]
 
 preparer = argus.environment:DevstackEnvironmentPreparer
@@ -71,6 +77,14 @@ stop_commands = screen -S stack -X quit
 
 preparer = argus.environment:DevstackEnvironmentPreparer
 config = devstack_configuration_configdrive_iso9660_drive
+start_commands = screen -dm -c /home/devstack/devstack/stack-screenrc
+stop_commands = screen -S stack -X quit
+
+
+[environment_devstack_static_network]
+
+preparer = argus.environment:DevstackEnvironmentPreparer
+config = devstack_configuration_static_network
 start_commands = screen -dm -c /home/devstack/devstack/stack-screenrc
 stop_commands = screen -S stack -X quit
 
@@ -212,4 +226,5 @@ service_type = maas
 [scenario_networkconfig_windows: base_smoke_windows]
 
 scenario = argus.scenarios.cloud:NetworkWindowsScenario
-test_classes = argus.tests.cloud.windows.test_smoke:TestStaticNetwork
+test_classes = argus.tests.cloud.smoke:TestStaticNetwork
+environment = environment_devstack_static_network


### PR DESCRIPTION
- move the test class to a non platform dependent module
- run the test(s) through an envinronment that enables flat network injection
