### PR TITLE
Remove monkey patching under DNS setting

### DIFF
--- a/argus/util.py
+++ b/argus/util.py
@@ -16,6 +16,7 @@
 import argparse
 import base64
 import contextlib
+import collections
 import importlib
 import itertools
 import logging
@@ -371,6 +372,11 @@ def restore_excepthook():
         yield
     finally:
         sys.excepthook = original
+
+
+def get_namedtuple(name, members, values):
+    nt_class = collections.namedtuple(name, members)
+    return nt_class(*values)
 
 
 class ConfigurationPatcher(object):


### PR DESCRIPTION
Instead of patching the code to automatically add desired
DNS name servers, just update the newly created subnets
directly with values from argus config.
