### PR TITLE
Test local scripts return codes

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -450,3 +450,18 @@ class CloudbaseinitKeysRecipe(CloudbaseinitHTTPRecipe,
                   "cloudbaseinit.plugins.windows.winrmlistener."
                   "ConfigWinRMListenerPlugin",
             execute_function=self._execute)
+
+
+class CloudbaseinitLocalScriptsRecipe(CloudbaseinitRecipe):
+    """Recipe for testing local scripts return codes."""
+
+    def pre_sysprep(self):
+        super(CloudbaseinitLocalScriptsRecipe, self).pre_sysprep()
+        LOG.info("Download reboot-required local script.")
+
+        cbdir = introspection.get_cbinit_dir(self._execute)
+        cmd = ("powershell Invoke-WebRequest -uri "
+               "{}/windows/reboot.cmd -outfile "
+               "'C:\\Scripts\\reboot.cmd'")
+        cmd = cmd.format(CONF.argus.resources, cbdir)
+        self._execute(cmd)

--- a/argus/resources/windows/reboot.cmd
+++ b/argus/resources/windows/reboot.cmd
@@ -1,0 +1,13 @@
+@echo off
+
+set path=C:\reboot
+
+:first
+if exist %path% goto second
+echo first
+mkdir %path%
+exit /b 1003
+
+:second
+echo second
+mkdir %path%2

--- a/argus/tests/cloud/windows/test_smoke.py
+++ b/argus/tests/cloud/windows/test_smoke.py
@@ -198,3 +198,12 @@ class TestNextLogonPassword(base.TestBaseArgus):
         self.assertEqual(flags & self.ads_uf_password_expired,
                          self.ads_uf_password_expired,
                          "The user have different flags than expected.")
+
+
+class TestLocalScripts(base.TestBaseArgus):
+
+    def test_local_scripts(self):
+        """Check if the script(s) executed entirely."""
+        names = self.introspection.list_location("C:\\")
+        self.assertIn("reboot", names)
+        self.assertIn("reboot2", names)

--- a/etc/argus.conf
+++ b/etc/argus.conf
@@ -287,3 +287,10 @@ recipe = argus.recipes.cloud.windows:ClearPasswordLogonRecipe
 test_classes = argus.tests.cloud.windows.test_smoke:TestNextLogonPassword,
                argus.tests.cloud.smoke:TestNoError,
 metadata = {"admin_pass": "PASsw0r4&!="}
+
+
+[scenario_local_scripts_windows : base_smoke_windows]
+
+test_classes = argus.tests.cloud.windows.test_smoke:TestSmoke,
+               argus.tests.cloud.windows.test_smoke:TestLocalScripts,
+recipe = argus.recipes.cloud.windows:CloudbaseinitLocalScriptsRecipe


### PR DESCRIPTION
Test if after executing a specific batch script by the
localscripts plugin, the instance reboots and lets the
service to successfully reexecute the script.
