### PR TITLE
Add CLI option for installer templating

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -95,9 +95,11 @@ class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):
 
     def install_cbinit(self):
         """Run the installation script for CloudbaseInit."""
-        installer = "CloudbaseInitSetup_{}_{}.msi".format(
-            self.build.capitalize(),
-            self.arch)
+        opts = util.parse_cli()
+        installer = opts.installer_template.format(
+            build=self.build,
+            arch=self.arch
+        )
         LOG.info("Run the downloaded installation script "
                  "using the installer %r with service %r.",
                  installer, self._service_type)

--- a/argus/runner.py
+++ b/argus/runner.py
@@ -193,7 +193,7 @@ def _build_scenarios_classes(scenario):
 def _cloud_scenarios_builder(partial_scenarios):
     """Build cloud specific custom scenarios objects."""
     opts = util.parse_cli()
-    builds = set(opts.builds) if opts.builds else {util.BUILDS.beta}
+    builds = set(opts.builds) if opts.builds else {util.BUILDS.Beta}
     arches = set(opts.arches) if opts.arches else {util.ARCHES.x64}
     scenarios = []
     for partial_scenario in partial_scenarios:

--- a/argus/util.py
+++ b/argus/util.py
@@ -314,6 +314,10 @@ def parse_cli():
     cloud.add_argument("-a", "--arches", action="append",
                        choices=list(ARCHES),
                        help="Choose what installer architectures to test.")
+    cloud.add_argument("-i", "--installer-template", metavar="TEMPLATE",
+                       default="CloudbaseInitSetup_{build}_{arch}.msi",
+                       help="Specify a custom installer template. "
+                            "Default: CloudbaseInitSetup_{build}_{arch}.msi")
     cloud.add_argument("--patch-install", metavar="URL",
                        help='Pass a link that points *directly* to a '
                             'zip file containing the installed version. '
@@ -475,7 +479,7 @@ class ConfigurationPatcher(object):
 
 LOG = get_logger()
 
-_BUILDS = ["beta", "stable"]
+_BUILDS = ["Beta", "Stable", "test"]
 _ARCHES = ["x64", "x86"]
 BUILDS = get_namedtuple("BUILDS", _BUILDS, _BUILDS)
 ARCHES = get_namedtuple("ARCHES", _ARCHES, _ARCHES)


### PR DESCRIPTION
Customize the cloudbase-init installer name by providing
an explicit template format to test different installer types.
