### PR TITLE
Fix for compatibility with the latest version of Tempest

### DIFF
--- a/argus/scenarios/base.py
+++ b/argus/scenarios/base.py
@@ -27,6 +27,7 @@ from argus import util
 with util.restore_excepthook():
     from tempest import clients
     from tempest.common import credentials
+    from tempest.common import waiters
 
 
 CONF = util.get_config()
@@ -131,7 +132,8 @@ class BaseArgusScenario(object):
             self._image.image_ref,
             self._image.flavor_ref,
             **kwargs)
-        self._servers_client.wait_for_server_status(server['id'], wait_until)
+        waiters.wait_for_server_status(
+            self._servers_client, server['id'], wait_until)
         return server
 
     def _create_keypair(self):
@@ -335,8 +337,8 @@ class BaseArgusScenario(object):
     def reboot_instance(self):
         self._servers_client.reboot(server_id=self._server['id'],
                                     reboot_type='soft')
-        self._servers_client.wait_for_server_status(self._server['id'],
-                                                    'ACTIVE')
+        waiters.wait_for_server_status(
+            self._servers_client, self._server['id'], 'ACTIVE')
 
     def prepare_instance(self):
         recipe = self._prepare_instance()

--- a/argus/scenarios/cloud.py
+++ b/argus/scenarios/cloud.py
@@ -23,6 +23,7 @@ from argus import util
 
 with util.restore_excepthook():
     from tempest.common import isolated_creds
+    from tempest.common import waiters
 
 
 CONF = util.get_config()
@@ -227,13 +228,13 @@ class RescueWindowsScenario(BaseWindowsScenario):
         admin_pass = self._image.default_ci_password
         self._servers_client.rescue_server(self._server['id'],
                                            adminPass=admin_pass)
-        self._servers_client.wait_for_server_status(self._server['id'],
-                                                    'RESCUE')
+        waiters.wait_for_server_status(
+            self._servers_client, self._server['id'], 'RESCUE')
 
     def unrescue_server(self):
         self._servers_client.unrescue_server(self._server['id'])
-        self._servers_client.wait_for_server_status(self._server['id'],
-                                                    'ACTIVE')
+        waiters.wait_for_server_status(
+            self._servers_client, self._server['id'], 'ACTIVE')
 
 
 class BaseServiceMockMixin(object):


### PR DESCRIPTION
ServersClient.wait_for_server_status for removed from Tempest.
I have replace all calls to the above method with
tempest.common.waiters.wait_for_server_status.
