### PR TITLE
Changed run_command_until_condition not to ignore retry_count param

### DIFF
--- a/argus/recipes/base.py
+++ b/argus/recipes/base.py
@@ -67,7 +67,7 @@ class BaseRecipe(object):
                                  delay=RETRY_DELAY):
         """Execute a command until the condition is met without returning."""
         self._remote_client.run_command_until_condition(
-            cmd, cond, count=count, delay=delay)
+            cmd, cond, retry_count=count, delay=delay)
 
     @abc.abstractmethod
     def prepare(self):

--- a/argus/recipes/base.py
+++ b/argus/recipes/base.py
@@ -61,7 +61,7 @@ class BaseRecipe(object):
         # Also, if the retrying limit is reached, `ArgusTimeoutError`
         # will be raised.
         return self._remote_client.run_command_with_retry(
-            cmd, retry_count=count, delay=delay)[0]
+            cmd, count=count, delay=delay)[0]
 
     def _execute_until_condition(self, cmd, cond, count=RETRY_COUNT,
                                  delay=RETRY_DELAY):

--- a/argus/recipes/base.py
+++ b/argus/recipes/base.py
@@ -61,7 +61,7 @@ class BaseRecipe(object):
         # Also, if the retrying limit is reached, `ArgusTimeoutError`
         # will be raised.
         return self._remote_client.run_command_with_retry(
-            cmd, count=count, delay=delay)[0]
+            cmd, retry_count=count, delay=delay)[0]
 
     def _execute_until_condition(self, cmd, cond, count=RETRY_COUNT,
                                  delay=RETRY_DELAY):

--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -172,7 +172,7 @@ class TestCloudstackUpdatePasswordSmoke(base.TestBaseArgus):
         remote_client.run_command_until_condition(
             wait_cmd,
             lambda out: out.strip() == 'Stopped',
-            count=util.RETRY_COUNT, delay=util.RETRY_DELAY)
+            retry_count=util.RETRY_COUNT, delay=util.RETRY_DELAY)
 
     def _test_password(self, password, expected):
         # Set the password in the Password Server.

--- a/argus/tests/cloud/windows/test_smoke.py
+++ b/argus/tests/cloud/windows/test_smoke.py
@@ -169,7 +169,7 @@ class TestNextLogonPassword(base.TestBaseArgus):
         remote_client.run_command_until_condition(
             wait_cmd,
             lambda out: out.strip() == 'Stopped',
-            count=util.RETRY_COUNT, delay=util.RETRY_DELAY)
+            retry_count=util.RETRY_COUNT, delay=util.RETRY_DELAY)
 
     def test_next_logon_password_not_changed(self):
         self._wait_for_completion()

--- a/argus/util.py
+++ b/argus/util.py
@@ -134,8 +134,8 @@ class WinRemoteClient(remote_client.WinRemoteClient):
                 LOG.debug("Retrying...")
                 time.sleep(delay)
 
-    def run_command_until_condition(self, cmd, cond,
-                                    count=RETRY_COUNT, delay=RETRY_DELAY):
+    def run_command_until_condition(self, cmd, cond, retry_count=RETRY_COUNT,
+                                    delay=RETRY_DELAY):
         """Run the given `cmd` until a condition `cond` occurs.
 
         :param cond:
@@ -148,18 +148,34 @@ class WinRemoteClient(remote_client.WinRemoteClient):
         This method uses and behaves like `run_command_with_retry` but
         with an additional condition parameter.
         """
-        while True:
-            stdout, stderr, _ = self.run_command_with_retry(
-                cmd, count=count, delay=delay)
+
+        # countdown normalization
+        if not retry_count or retry_count < 0:
+            retry_count = 0
+
+        try:
+            stdout, stderr, _ = self.run_command(cmd)
+        except Exception as exc:  # pylint: disable-broad-except
+            LOG.debug("Command failed with %r.", exc)
+        else:
             if stderr:
                 raise exceptions.ArgusCLIError(
                     "Executing command {!r} failed with {!r}."
                     .format(cmd, stderr))
             elif cond(stdout):
-                break
+                return
             else:
                 LOG.debug("Condition not met, retrying...")
-                time.sleep(delay)
+
+        if retry_count > 0:
+            LOG.debug("Retrying...")
+            time.sleep(delay)
+            self.run_command_until_condition(
+                cmd, cond, retry_count=retry_count - 1, delay=delay)
+        else:
+            raise exceptions.ArgusTimeoutError(
+                "Command {!r} failed too many times."
+                .format(cmd))
 
 
 def get_local_ip():


### PR DESCRIPTION
Renamed count param to retry_count because count=1 implies that the command will run once but in reality it runs twice. When you specify retry_count=1 it's intuitive that it will run twice, first try and one retry.
