### PR TITLE
Remove plugins counting test and introspection

### DIFF
--- a/argus/config.py
+++ b/argus/config.py
@@ -226,19 +226,12 @@ class ConfigurationParser(object):
     def cloudbaseinit(self):
         cloudbaseinit = collections.namedtuple(
             'cloudbaseinit',
-            'expected_plugins_count created_user group')
-
-        try:
-            expected_plugins_count = self._parser.getint(
-                'cloudbaseinit',
-                'expected_plugins_count')
-        except (six.moves.configparser.NoOptionError, ValueError):
-            expected_plugins_count = 13
+            'created_user group')
 
         group = self._parser.get('cloudbaseinit', 'group')
         created_user = self._parser.get('cloudbaseinit', 'created_user')
 
-        return cloudbaseinit(expected_plugins_count, created_user, group)
+        return cloudbaseinit(created_user, group)
 
     @property
     def images(self):

--- a/argus/introspection/cloud/base.py
+++ b/argus/introspection/cloud/base.py
@@ -28,10 +28,6 @@ class BaseInstanceIntrospection(object):
         self.image = image
 
     @abc.abstractmethod
-    def get_plugins_count(self):
-        """Return the plugins count from the instance."""
-
-    @abc.abstractmethod
     def get_disk_size(self):
         """Return the disk size from the instance."""
 

--- a/argus/introspection/cloud/windows.py
+++ b/argus/introspection/cloud/windows.py
@@ -189,15 +189,6 @@ def get_cbinit_key(execute_function):
 class InstanceIntrospection(base.BaseInstanceIntrospection):
     """Utilities for introspecting a Windows instance."""
 
-    def get_plugins_count(self):
-        exec_func = self.remote_client.run_command_verbose
-        key = "{0}\\{1}\\Plugins".format(
-            get_cbinit_key(exec_func),
-            self.instance)
-        cmd = 'powershell (Get-Item %s).ValueCount' % key
-        stdout = exec_func(cmd)
-        return int(stdout)
-
     def get_disk_size(self):
         cmd = ('powershell (Get-WmiObject "win32_logicaldisk | '
                'where -Property DeviceID -Match C:").Size')

--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -269,12 +269,6 @@ class TestsBaseSmoke(TestCreatedUser,
                      base.TestBaseArgus):
     """Various smoke tests for testing cloudbaseinit."""
 
-    def test_plugins_count(self):
-        # Test that we have the expected numbers of plugins.
-        plugins_count = self.introspection.get_plugins_count()
-        self.assertEqual(CONF.cloudbaseinit.expected_plugins_count,
-                         plugins_count)
-
     def test_disk_expanded(self):
         # Test the disk expanded properly.
         image = self.manager.get_image_by_ref()

--- a/etc/argus.conf
+++ b/etc/argus.conf
@@ -10,7 +10,6 @@ resources = https://raw.githubusercontent.com/PCManticore/argus-ci/develop/argus
 
 [cloudbaseinit]
 
-expected_plugins_count = 13
 created_user = Admin
 group = Administrators
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,6 @@ class TestConfig(unittest.TestCase):
         dns_nameservers = a,b
 
         [cloudbaseinit]
-        expected_plugins_count = 4
         created_user = 5
         group = 4
 
@@ -87,7 +86,6 @@ class TestConfig(unittest.TestCase):
         dns_nameservers = a,b
 
         [cloudbaseinit]
-        expected_plugins_count = 4
         group = 4
         created_user = 5
 
@@ -165,7 +163,6 @@ class TestConfig(unittest.TestCase):
         dns_nameservers = a,b
 
         [cloudbaseinit]
-        expected_plugins_count = 4
         group = 4
         created_user = 5
 
@@ -215,7 +212,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual('d', parsed.argus.log_format)
         self.assertEqual(['a', 'b'], parsed.argus.dns_nameservers)
 
-        self.assertEqual(4, parsed.cloudbaseinit.expected_plugins_count)
         self.assertEqual('4', parsed.cloudbaseinit.group)
         self.assertEqual('5', parsed.cloudbaseinit.created_user)
 


### PR DESCRIPTION
This was done due to this patch: https://review.openstack.org/#/c/227811/
where 2 plugins will be executed at each boot (for preparing the
metadata providers accessibility) and the counting is different
with the older versions.
